### PR TITLE
Support MPEG 2.5

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/mp3/Mp3FrameReader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/mp3/Mp3FrameReader.java
@@ -88,16 +88,22 @@ public class Mp3FrameReader {
     }
 
     private boolean parseFrameAt(int scanOffset) {
-        if (scanOffset >= HEADER_SIZE && (frameSize = Mp3Decoder.getFrameSize(scanBuffer, scanOffset - HEADER_SIZE)) > 0) {
-            for (int i = 0; i < HEADER_SIZE; i++) {
-                frameBuffer[i] = scanBuffer[scanOffset - HEADER_SIZE + i];
-            }
+        int offset = scanOffset - HEADER_SIZE;
+        boolean invalid = offset < 0
+            || !Mp3Decoder.hasFrameSync(scanBuffer, offset)
+            || Mp3Decoder.isUnsupportedVersion(scanBuffer, offset)
+            || !Mp3Decoder.isValidFrame(scanBuffer, offset);
 
-            frameBufferPosition = HEADER_SIZE;
-            return true;
+        if (invalid)
+            return false;
+
+        frameSize = Mp3Decoder.getFrameSize(scanBuffer, offset);
+        for (int i = 0; i < HEADER_SIZE; i++) {
+            frameBuffer[i] = scanBuffer[offset + i];
         }
 
-        return false;
+        frameBufferPosition = HEADER_SIZE;
+        return true;
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/lavalink-devs/lavaplayer/issues/28.
I've tested playback and seeking on a bunch of MPEG 1, a few MPEG 2, and two MPEG 2.5 files, and they all work. I've also rewritten a good chunk of Mp3Decoder.java, so hopefully there aren't any unforeseen regressions.