### PR TITLE
Fix a bug with MPEG parsing that would lead to range exceptions

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/natives/mp3/Mp3Decoder.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/natives/mp3/Mp3Decoder.java
@@ -179,7 +179,7 @@ public class Mp3Decoder extends NativeResourceHolder {
 
         private static int getMaxFrameSize() {
             int bitRate = MPEG_1.bitrateIndex[MPEG_1.bitrateIndex.length - 1] * 1000;
-            int sampleRate = MPEG_1.samplerateIndex[1];
+            int sampleRate = MPEG_1.samplerateIndex[2];
             return MPEG_1.calculateFrameSize(bitRate, sampleRate, true);
         }
 


### PR DESCRIPTION
Fixes https://discord.com/channels/125227483518861312/263484072389640193/1141409353736392784 (and playback of MP3s with large frames in general)