### PR TITLE
specify all request timeouts

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/HttpClientTools.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/HttpClientTools.java
@@ -39,11 +39,15 @@ public class HttpClientTools {
 
     public static final RequestConfig DEFAULT_REQUEST_CONFIG = RequestConfig.custom()
         .setConnectTimeout(3000)
+        .setConnectionRequestTimeout(3000)
+        .setSocketTimeout(3000)
         .setCookieSpec(CookieSpecs.STANDARD)
         .build();
 
     private static final RequestConfig NO_COOKIES_REQUEST_CONFIG = RequestConfig.custom()
         .setConnectTimeout(3000)
+        .setConnectionRequestTimeout(3000)
+        .setSocketTimeout(3000)
         .setCookieSpec(CookieSpecs.IGNORE_COOKIES)
         .build();
 


### PR DESCRIPTION
it seems like not specifying `ConnectionRequestTimeout` & `SocketTimeout` can cause issues where requests don't correctly timeout

Discord Help Post https://discord.com/channels/1082302532421943407/1142094131586416711