### PR TITLE
Substitute null values for playlist tracks with missing author fields

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
@@ -17,7 +17,6 @@ import org.apache.http.entity.StringEntity;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -167,9 +166,8 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
             if (!item.get("isPlayable").isNull() && !shortBylineText.isNull()) {
                 String videoId = item.get("videoId").text();
                 JsonBrowser titleField = item.get("title");
-                String title = Optional.ofNullable(titleField.get("simpleText").text())
-                    .orElse(titleField.get("runs").index(0).get("text").text());
-                String author = shortBylineText.get("runs").index(0).get("text").text();
+                String title = titleField.get("simpleText").textOrDefault(titleField.get("runs").index(0).get("text").text());
+                String author = shortBylineText.get("runs").index(0).get("text").textOrDefault("Unknown artist");
                 JsonBrowser lengthSeconds = item.get("lengthSeconds");
                 long duration = Units.secondsToMillis(lengthSeconds.asLong(Units.DURATION_SEC_UNKNOWN));
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/JsonBrowser.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/JsonBrowser.java
@@ -209,6 +209,11 @@ public class JsonBrowser {
         return null;
     }
 
+    public String textOrDefault(String defaultValue) {
+        String value = text();
+        return value != null ? value : defaultValue;
+    }
+
     public boolean asBoolean(boolean defaultValue) {
         if (node != null) {
             if (node.isBoolean()) {


### PR DESCRIPTION
For some obscure reason, YouTube do not return an author field for select tracks so we substitute what would be a null value with a placeholder of "Unknown artist" (consistent with the default value of `AudioTrackInfoBuilder#UNKNOWN_ARTIST`).