### PR TITLE
[v1-legacy] Substitute null values for playlist tracks with missing author fields

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
@@ -16,7 +16,6 @@ import org.apache.http.entity.StringEntity;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -166,9 +165,8 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
       if (!item.get("isPlayable").isNull() && !shortBylineText.isNull()) {
         String videoId = item.get("videoId").text();
         JsonBrowser titleField = item.get("title");
-        String title = Optional.ofNullable(titleField.get("simpleText").text())
-          .orElse(titleField.get("runs").index(0).get("text").text());
-        String author = shortBylineText.get("runs").index(0).get("text").text();
+        String title = titleField.get("simpleText").textOrDefault(titleField.get("runs").index(0).get("text").text());
+        String author = shortBylineText.get("runs").index(0).get("text").textOrDefault("Unknown artist");
         JsonBrowser lengthSeconds = item.get("lengthSeconds");
         long duration = Units.secondsToMillis(lengthSeconds.asLong(Units.DURATION_SEC_UNKNOWN));
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/JsonBrowser.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/JsonBrowser.java
@@ -148,6 +148,11 @@ public class JsonBrowser {
     return null;
   }
 
+  public String textOrDefault(String defaultValue) {
+    String value = text();
+    return value != null ? value : defaultValue;
+  }
+
   public boolean asBoolean(boolean defaultValue) {
     if (node != null) {
       if (node.isBoolean()) {


### PR DESCRIPTION
Identical to #45, just for `v1-legacy` branch.