### PR TITLE
Use stream preview thumbnail instead of channel icon

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/twitch/TwitchStreamAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/twitch/TwitchStreamAudioSourceManager.java
@@ -25,6 +25,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Locale;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Matcher;
@@ -81,7 +82,11 @@ public class TwitchStreamAudioSourceManager implements AudioSourceManager, HttpC
         } else {
             String title = channelInfo.get("lastBroadcast").get("title").text();
 
-            final String thumbnail = channelInfo.get("profileImageURL").text().replaceFirst("-70x70", "-300x300");
+            final String thumbnail = String.format(
+                "https://static-cdn.jtvnw.net/previews-ttv/live_user_%s-440x248.jpg",
+                // Using root because the turkish lowercase "i" does not have the little dot above the letter when defaulted
+                streamName.toLowerCase(Locale.ROOT)
+            );
 
             return new TwitchStreamAudioTrack(new AudioTrackInfo(
                 title,


### PR DESCRIPTION
This replaces the profile image with the actual stream preview so it conforms to what twitch has as thumbnails

before: https://static-cdn.jtvnw.net/jtv_user_pictures/21df6206-6be7-4a70-937d-e4853b99c475-profile_image-300x300.png

After: https://static-cdn.jtvnw.net/previews-ttv/live_user_esamarathon-440x248.jpg