### PR TITLE
Fix `Target host is not specified` with HLS relative urls in m3u8 playlists

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/playlists/HlsStreamSegmentUrlProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/playlists/HlsStreamSegmentUrlProvider.java
@@ -19,6 +19,7 @@ public class HlsStreamSegmentUrlProvider extends M3uStreamSegmentUrlProvider {
     private volatile String segmentPlaylistUrl;
 
     public HlsStreamSegmentUrlProvider(String streamListUrl, String segmentPlaylistUrl) {
+        super(streamListUrl);
         this.streamListUrl = streamListUrl;
         this.segmentPlaylistUrl = segmentPlaylistUrl;
     }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/beam/BeamSegmentUrlProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/beam/BeamSegmentUrlProvider.java
@@ -28,6 +28,7 @@ public class BeamSegmentUrlProvider extends M3uStreamSegmentUrlProvider {
      * @param channelId Channel ID number.
      */
     public BeamSegmentUrlProvider(String channelId) {
+        super(null);
         this.channelId = channelId;
     }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/stream/M3uStreamSegmentUrlProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/stream/M3uStreamSegmentUrlProvider.java
@@ -142,9 +142,9 @@ public abstract class M3uStreamSegmentUrlProvider {
 
     protected boolean isAbsoluteUrl(String url) {
         try {
-            // We only want to return false here if we have a baseUrl (for converting relative URLs)
-            // and the provided url is incomplete (relative).
-            return this.baseUrl != null || new URI(url).isAbsolute();
+            // A URL is considered absolute if we don't have a baseUrl (so cannot convert a relative URL)
+            // or if URI#isAbsolute returns true.
+            return this.baseUrl == null || new URI(url).isAbsolute();
         } catch (URISyntaxException e) {
             return false;
         }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/stream/M3uStreamSegmentUrlProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/stream/M3uStreamSegmentUrlProvider.java
@@ -13,6 +13,7 @@ import org.apache.http.client.methods.HttpUriRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +30,20 @@ public abstract class M3uStreamSegmentUrlProvider {
     private static final long SEGMENT_WAIT_STEP_MS = 200;
     private static final RequestConfig streamingRequestConfig = RequestConfig.custom().setSocketTimeout(5000).setConnectionRequestTimeout(5000).setConnectTimeout(5000).build();
 
+    protected String baseUrl;
     protected SegmentInfo lastSegment;
+
+    protected M3uStreamSegmentUrlProvider(String originUrl) {
+        if (originUrl != null) {
+            if (originUrl.endsWith("/")) {
+                originUrl = originUrl.substring(0, originUrl.length() - 1);
+            }
+
+            this.baseUrl = originUrl.substring(0, originUrl.lastIndexOf("/"));
+        } else {
+            this.baseUrl = null;
+        }
+    }
 
     protected static String createSegmentUrl(String playlistUrl, String segmentName) {
         return URI.create(playlistUrl).resolve(segmentName).toString();
@@ -122,6 +136,20 @@ public abstract class M3uStreamSegmentUrlProvider {
 
     protected abstract HttpUriRequest createSegmentGetRequest(String url);
 
+    protected boolean isAbsoluteUrl(String url) {
+        try {
+            // We only want to return false here if we have a baseUrl (for converting relative URLs)
+            // and the provided url is incomplete (relative).
+            return this.baseUrl != null || new URI(url).isAbsolute();
+        } catch (URISyntaxException e) {
+            return false;
+        }
+    }
+
+    protected String getAbsoluteUrl(String url) {
+        return baseUrl + ((url.startsWith("/")) ? url : "/" + url);
+    }
+
     protected List<ChannelStreamInfo> loadChannelStreamsList(String[] lines) {
         ExtendedM3uParser.Line streamInfoLine = null;
 
@@ -133,7 +161,8 @@ public abstract class M3uStreamSegmentUrlProvider {
             if (line.isData() && streamInfoLine != null) {
                 String quality = getQualityFromM3uDirective(streamInfoLine);
                 if (quality != null) {
-                    streams.add(new ChannelStreamInfo(quality, line.lineData));
+                    String lineData = line.lineData;
+                    streams.add(new ChannelStreamInfo(quality, isAbsoluteUrl(lineData) ? lineData : getAbsoluteUrl(lineData)));
                 }
 
                 streamInfoLine = null;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/stream/M3uStreamSegmentUrlProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/stream/M3uStreamSegmentUrlProvider.java
@@ -33,6 +33,10 @@ public abstract class M3uStreamSegmentUrlProvider {
     protected String baseUrl;
     protected SegmentInfo lastSegment;
 
+    protected M3uStreamSegmentUrlProvider() {
+        this(null);
+    }
+
     protected M3uStreamSegmentUrlProvider(String originUrl) {
         if (originUrl != null) {
             if (originUrl.endsWith("/")) {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/twitch/TwitchStreamSegmentUrlProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/twitch/TwitchStreamSegmentUrlProvider.java
@@ -35,6 +35,7 @@ public class TwitchStreamSegmentUrlProvider extends M3uStreamSegmentUrlProvider 
      * @param manager     Twitch source manager.
      */
     public TwitchStreamSegmentUrlProvider(String channelName, TwitchStreamAudioSourceManager manager) {
+        super(null);
         this.channelName = channelName;
         this.manager = manager;
         this.tokenExpirationTime = -1;


### PR DESCRIPTION
This PR attempts to rectify an issue within HLS parsing where relative URLs are not converted to an absolute URL, causing a `Target host is not specified` error message due to missing first part of the URL (thus, Lavaplayer doesn't know where to connect to, to grab the next segments in the playlist).

This has only been tested with https://hls-01-radiorecord.hostingradio.ru/record/112/playlist.m3u8.

I would advise further testing, including URLs from playlists containing absolute URLs to ensure backwards compatibility. I've tried to ensure this won't affect previously supported URLs however more testing is always welcome, as well as any general feedback.