### PR TITLE
Fix NicoNico Track

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/AudioSourceManagers.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/AudioSourceManagers.java
@@ -41,7 +41,7 @@ public class AudioSourceManagers {
         playerManager.registerSourceManager(new TwitchStreamAudioSourceManager());
         playerManager.registerSourceManager(new BeamAudioSourceManager());
         playerManager.registerSourceManager(new GetyarnAudioSourceManager());
-        playerManager.registerSourceManager(new NicoAudioSourceManager(null, null));
+        playerManager.registerSourceManager(new NicoAudioSourceManager());
         playerManager.registerSourceManager(new HttpAudioSourceManager(containerRegistry));
     }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/AudioSourceManagers.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/AudioSourceManagers.java
@@ -41,8 +41,8 @@ public class AudioSourceManagers {
         playerManager.registerSourceManager(new TwitchStreamAudioSourceManager());
         playerManager.registerSourceManager(new BeamAudioSourceManager());
         playerManager.registerSourceManager(new GetyarnAudioSourceManager());
+        playerManager.registerSourceManager(new NicoAudioSourceManager(null, null));
         playerManager.registerSourceManager(new HttpAudioSourceManager(containerRegistry));
-        playerManager.registerSourceManager(new NicoAudioSourceManager(null,null));
     }
 
     /**

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/AudioSourceManagers.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/AudioSourceManagers.java
@@ -7,6 +7,7 @@ import com.sedmelluq.discord.lavaplayer.source.beam.BeamAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.source.getyarn.GetyarnAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.source.http.HttpAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.source.local.LocalAudioSourceManager;
+import com.sedmelluq.discord.lavaplayer.source.nico.NicoAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.source.twitch.TwitchStreamAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.source.vimeo.VimeoAudioSourceManager;
@@ -41,6 +42,7 @@ public class AudioSourceManagers {
         playerManager.registerSourceManager(new BeamAudioSourceManager());
         playerManager.registerSourceManager(new GetyarnAudioSourceManager());
         playerManager.registerSourceManager(new HttpAudioSourceManager(containerRegistry));
+        playerManager.registerSourceManager(new NicoAudioSourceManager(null,null));
     }
 
     /**

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/HeartbeatingHttpStream.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/HeartbeatingHttpStream.java
@@ -60,7 +60,6 @@ public class HeartbeatingHttpStream extends PersistentHttpStream implements Clos
     }
 
     protected void setupHeartbeat() {
-        System.out.println("heartbeat.");
         log.debug("Heartbeat every {} milliseconds to URL: {}", heartbeatInterval, heartbeatUrl);
 
         heartbeatFuture = executor.scheduleAtFixedRate(() -> {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/HeartbeatingHttpStream.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/HeartbeatingHttpStream.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * An extension of PersistentHttpStream that allows for sending heartbeats to a secondary URL.
  */
-public class HeartbeatingHttpStream extends PersistentHttpStream implements Closeable {
+public class HeartbeatingHttpStream extends PersistentHttpStream implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(HeartbeatingHttpStream.class);
     private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/HeartbeatingHttpStream.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/HeartbeatingHttpStream.java
@@ -26,7 +26,6 @@ public class HeartbeatingHttpStream extends PersistentHttpStream implements Clos
     private static final Logger log = LoggerFactory.getLogger(HeartbeatingHttpStream.class);
     private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 
-
     private String heartbeatUrl;
     private int heartbeatInterval;
     private String heartbeatPayload;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/HeartbeatingHttpStream.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/HeartbeatingHttpStream.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * An extension of PersistentHttpStream that allows for sending heartbeats to a secondary URL.
  */
-public class HeartbeatingHttpStream extends PersistentHttpStream implements AutoCloseable {
+public class HeartbeatingHttpStream extends PersistentHttpStream {
     private static final Logger log = LoggerFactory.getLogger(HeartbeatingHttpStream.class);
     private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/HeartbeatingHttpStream.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/HeartbeatingHttpStream.java
@@ -1,0 +1,96 @@
+package com.sedmelluq.discord.lavaplayer.source.nico;
+
+import com.sedmelluq.discord.lavaplayer.tools.JsonBrowser;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
+import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
+import com.sedmelluq.discord.lavaplayer.tools.io.PersistentHttpStream;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An extension of PersistentHttpStream that allows for sending heartbeats to a secondary URL.
+ */
+public class HeartbeatingHttpStream extends PersistentHttpStream implements Closeable {
+    private static final Logger log = LoggerFactory.getLogger(HeartbeatingHttpStream.class);
+    private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+
+    private String heartbeatUrl;
+    private int heartbeatInterval;
+    private String heartbeatPayload;
+
+    private ScheduledFuture<?> heartbeatFuture;
+
+    /**
+     * Creates a new heartbeating http stream.
+     * @param httpInterface The HTTP interface to use for requests.
+     * @param contentUrl The URL to play from.
+     * @param contentLength The length of the content. Null if unknown.
+     * @param heartbeatUrl The URL to send heartbeat requests to.
+     * @param heartbeatInterval The interval at which to heartbeat, in milliseconds.
+     * @param heartbeatPayload The initial heartbeat payload.
+     */
+    public HeartbeatingHttpStream(
+        HttpInterface httpInterface,
+        URI contentUrl,
+        Long contentLength,
+        String heartbeatUrl,
+        int heartbeatInterval,
+        String heartbeatPayload
+    ) {
+        super(httpInterface, contentUrl, contentLength);
+
+        this.heartbeatUrl = heartbeatUrl;
+        this.heartbeatInterval = heartbeatInterval;
+        this.heartbeatPayload = heartbeatPayload;
+
+        setupHeartbeat();
+    }
+
+    protected void setupHeartbeat() {
+        System.out.println("heartbeat.");
+        log.debug("Heartbeat every {} milliseconds to URL: {}", heartbeatInterval, heartbeatUrl);
+
+        heartbeatFuture = executor.scheduleAtFixedRate(() -> {
+            try {
+                sendHeartbeat();
+            } catch (Throwable t) {
+                log.error("Heartbeat error!", t);
+                IOUtils.closeQuietly(this);
+            }
+        }, heartbeatInterval, heartbeatInterval, TimeUnit.MILLISECONDS);
+    }
+
+    protected void sendHeartbeat() throws IOException {
+        HttpPost request = new HttpPost(heartbeatUrl);
+        request.addHeader("Host", "api.dmc.nico");
+        request.addHeader("Connection", "keep-alive");
+        request.addHeader("Content-Type", "application/json");
+        request.addHeader("Origin", "https://www.nicovideo.jp");
+        request.setEntity(new StringEntity(heartbeatPayload));
+
+        try (CloseableHttpResponse response = httpInterface.execute(request)) {
+            HttpClientTools.assertSuccessWithContent(response, "heartbeat page");
+
+            heartbeatPayload = JsonBrowser.parse(response.getEntity().getContent()).get("data").format();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        heartbeatFuture.cancel(false);
+        super.close();
+    }
+}

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioSourceManager.java
@@ -50,6 +50,10 @@ public class NicoAudioSourceManager implements AudioSourceManager, HttpConfigura
     private final HttpInterfaceManager httpInterfaceManager;
     private final AtomicBoolean loggedIn;
 
+    public NicoAudioSourceManager() {
+        this(null, null);
+    }
+
     /**
      * @param email    Site account email
      * @param password Site account password

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioSourceManager.java
@@ -47,8 +47,6 @@ public class NicoAudioSourceManager implements AudioSourceManager, HttpConfigura
 
     private static final Pattern trackUrlPattern = Pattern.compile(TRACK_URL_REGEX);
 
-    private final String email;
-    private final String password;
     private final HttpInterfaceManager httpInterfaceManager;
     private final AtomicBoolean loggedIn;
 
@@ -57,10 +55,12 @@ public class NicoAudioSourceManager implements AudioSourceManager, HttpConfigura
      * @param password Site account password
      */
     public NicoAudioSourceManager(String email, String password) {
-        this.email = email;
-        this.password = password;
         httpInterfaceManager = HttpClientTools.createDefaultThreadLocalManager();
         loggedIn = new AtomicBoolean();
+        // Log in at the start
+        if (!DataFormatTools.isNullOrEmpty(email) && !DataFormatTools.isNullOrEmpty(password)) {
+            logIn(email,password);
+        }
     }
 
     @Override
@@ -80,8 +80,6 @@ public class NicoAudioSourceManager implements AudioSourceManager, HttpConfigura
     }
 
     private AudioTrack loadTrack(String videoId) {
-        checkLoggedIn();
-
         try (HttpInterface httpInterface = getHttpInterface()) {
             try (CloseableHttpResponse response = httpInterface.execute(new HttpGet("http://ext.nicovideo.jp/api/getthumbinfo/" + videoId))) {
                 int statusCode = response.getStatusLine().getStatusCode();
@@ -155,7 +153,7 @@ public class NicoAudioSourceManager implements AudioSourceManager, HttpConfigura
         httpInterfaceManager.configureBuilder(configurator);
     }
 
-    void checkLoggedIn() {
+    void logIn(String email, String password) {
         synchronized (loggedIn) {
             if (loggedIn.get()) {
                 return;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioSourceManager.java
@@ -193,6 +193,6 @@ public class NicoAudioSourceManager implements AudioSourceManager, HttpConfigura
     }
 
     private static String getWatchUrl(String videoId) {
-        return "http://www.nicovideo.jp/watch/" + videoId;
+        return "https://www.nicovideo.jp/watch/" + videoId;
     }
 }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioSourceManager.java
@@ -97,10 +97,10 @@ public class NicoAudioSourceManager implements AudioSourceManager, HttpConfigura
 
     private AudioTrack extractTrackFromXml(String videoId, Document document) {
         for (Element element : document.select(":root > thumb")) {
-            String uploader = element.select("user_nickname").first().text();
-            String title = element.select("title").first().text();
-            String thumbnailUrl = element.select("thumbnail_url").first().text();
-            long duration = DataFormatTools.durationTextToMillis(element.select("length").first().text());
+            String uploader = element.selectFirst("user_nickname").text();
+            String title = element.selectFirst("title").text();
+            String thumbnailUrl = element.selectFirst("thumbnail_url").text();
+            long duration = DataFormatTools.durationTextToMillis(element.selectFirst("length").text());
 
             return new NicoAudioTrack(new AudioTrackInfo(title,
                 uploader,

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioTrack.java
@@ -38,8 +38,6 @@ import java.util.stream.Collectors;
 public class NicoAudioTrack extends DelegatedAudioTrack {
     private static final Logger log = LoggerFactory.getLogger(NicoAudioTrack.class);
 
-    private static final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
-
     private final NicoAudioSourceManager sourceManager;
 
     private String heartbeatUrl;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioTrack.java
@@ -6,12 +6,10 @@ import com.sedmelluq.discord.lavaplayer.tools.DataFormatTools;
 import com.sedmelluq.discord.lavaplayer.tools.JsonBrowser;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
-import com.sedmelluq.discord.lavaplayer.tools.io.PersistentHttpStream;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
 import com.sedmelluq.discord.lavaplayer.track.DelegatedAudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.playback.LocalAudioTrackExecutor;
-import org.apache.commons.codec.binary.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -20,24 +18,13 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.jsoup.Jsoup;
-import org.jsoup.internal.StringUtil;
-import org.jsoup.nodes.Document;
 import org.jsoup.parser.Parser;
-import org.jsoup.safety.Safelist;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.URLDecoder;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioTrack.java
@@ -126,6 +126,10 @@ public class NicoAudioTrack extends DelegatedAudioTrack {
     }
 
     private JSONObject processJSON(JsonBrowser input) {
+        if (input.isNull()) {
+            throw new IllegalStateException("Invalid response received from NicoNico when loading video details");
+        }
+
         JSONObject lifetime = new JSONObject().put("lifetime", input.get("heartbeatLifetime").asLong(120000));
         JSONObject heartbeat = new JSONObject().put("heartbeat", lifetime);
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioTrack.java
@@ -9,19 +9,23 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
 import com.sedmelluq.discord.lavaplayer.track.DelegatedAudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.playback.LocalAudioTrackExecutor;
+import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.utils.URLEncodedUtils;
-import org.apache.http.util.EntityUtils;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.jsoup.Jsoup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.Map;
-
-import static com.sedmelluq.discord.lavaplayer.tools.DataFormatTools.convertToMapLayout;
+import java.util.Timer;
+import java.util.TimerTask;
 
 /**
  * Audio track that handles processing NicoNico tracks.
@@ -30,6 +34,10 @@ public class NicoAudioTrack extends DelegatedAudioTrack {
     private static final Logger log = LoggerFactory.getLogger(NicoAudioTrack.class);
 
     private final NicoAudioSourceManager sourceManager;
+
+    private String heartbeatURL;
+
+    private JSONObject info;
 
     /**
      * @param trackInfo     Track info
@@ -43,22 +51,32 @@ public class NicoAudioTrack extends DelegatedAudioTrack {
 
     @Override
     public void process(LocalAudioTrackExecutor localExecutor) throws Exception {
-        sourceManager.checkLoggedIn();
 
         try (HttpInterface httpInterface = sourceManager.getHttpInterface()) {
-            loadVideoMainPage(httpInterface);
             String playbackUrl = loadPlaybackUrl(httpInterface);
 
             log.debug("Starting NicoNico track from URL: {}", playbackUrl);
 
             try (PersistentHttpStream stream = new PersistentHttpStream(httpInterface, new URI(playbackUrl), null)) {
+                int heartbeat = (int) info.query("/session/keep_method/heartbeat/lifetime") - 1000;
+                Timer t = new Timer();
+                t.schedule(new TimerTask() {
+                    public void run() {
+                        try {
+                            sendHeartbeat(httpInterface);
+                        } catch (IOException ex) {
+                            log.error("Heartbeat error!",ex);
+                        }
+                    }
+                },heartbeat,heartbeat);
                 processDelegate(new MpegAudioTrack(trackInfo, stream), localExecutor);
+                t.cancel();
             }
         }
     }
 
-    private void loadVideoMainPage(HttpInterface httpInterface) throws IOException {
-        HttpGet request = new HttpGet("http://www.nicovideo.jp/watch/" + trackInfo.identifier);
+    private JSONObject loadVideoMainPage(HttpInterface httpInterface) throws IOException {
+        HttpGet request = new HttpGet(trackInfo.uri);
 
         try (CloseableHttpResponse response = httpInterface.execute(request)) {
             int statusCode = response.getStatusLine().getStatusCode();
@@ -66,24 +84,110 @@ public class NicoAudioTrack extends DelegatedAudioTrack {
                 throw new IOException("Unexpected status code from video main page: " + statusCode);
             }
 
-            EntityUtils.consume(response.getEntity());
+            return (JSONObject) new JSONObject(
+                Jsoup.parse(response.getEntity().getContent(), StandardCharsets.UTF_8.name(), "")
+                    .getElementById("js-initial-watch-data").attributes().get("data-api-data"))
+                .query("/media/delivery/movie/session");
         }
     }
 
     private String loadPlaybackUrl(HttpInterface httpInterface) throws IOException {
-        HttpGet request = new HttpGet("http://flapi.nicovideo.jp/api/getflv/" + trackInfo.identifier);
+        HttpPost request = new HttpPost("https://api.dmc.nico/api/sessions?_format=json");
+        request.addHeader("Host", "api.dmc.nico");
+        request.addHeader("Connection","keep-alive");
+        request.addHeader("Content-Type","application/json");
+        request.addHeader("Origin","https://www.nicovideo.jp");
+        request.setEntity(new StringEntity(processJSON(loadVideoMainPage(httpInterface)).toString()));
+
+        try (CloseableHttpResponse response = httpInterface.execute(request)) {
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != HttpStatus.SC_CREATED) {
+                throw new IOException("Unexpected status code from playback parameters page: " + statusCode);
+            }
+
+            info = new JSONObject(new JSONTokener(response.getEntity().getContent())).getJSONObject("data");
+            heartbeatURL = "https://api.dmc.nico/api/sessions/" + info.query("/session/id") + "?_format=json&_method=PUT";
+            log.debug("NicoNico heartbeat URL: {}", heartbeatURL);
+            return (String) info.query("/session/content_uri");
+        }
+    }
+
+    private void sendHeartbeat(HttpInterface httpInterface) throws IOException {
+        HttpPost request = new HttpPost(heartbeatURL);
+        request.addHeader("Host", "api.dmc.nico");
+        request.addHeader("Connection","keep-alive");
+        request.addHeader("Content-Type","application/json");
+        request.addHeader("Origin","https://www.nicovideo.jp");
+        request.setEntity(new StringEntity(info.toString()));
 
         try (CloseableHttpResponse response = httpInterface.execute(request)) {
             int statusCode = response.getStatusLine().getStatusCode();
             if (!HttpClientTools.isSuccessWithContent(statusCode)) {
-                throw new IOException("Unexpected status code from playback parameters page: " + statusCode);
+                throw new IOException("Unexpected status code from heartbeat: " + statusCode);
             }
 
-            String text = EntityUtils.toString(response.getEntity());
-            Map<String, String> format = convertToMapLayout(URLEncodedUtils.parse(text, StandardCharsets.UTF_8));
-
-            return format.get("url");
+            info = new JSONObject(new JSONTokener(response.getEntity().getContent())).getJSONObject("data");
         }
+    }
+
+    private static JSONObject processJSON(JSONObject input){
+        return new JSONObject().put("session",new JSONObject()
+            .put("content_type","movie")
+            .put("keep_method",new JSONObject()
+                .put("heartbeat",new JSONObject()
+                    .put("lifetime",input.getInt("heartbeatLifetime"))
+                )
+            )
+            .put("timing_constraint","unlimited")
+            .put("content_src_id_sets", new JSONArray()
+                .put(new JSONObject()
+                    .put("content_src_ids",new JSONArray()
+                        .put(new JSONObject()
+                            .put("src_id_to_mux",new JSONObject()
+                                .put("video_src_ids",input.getJSONArray("videos"))
+                                .put("audio_src_ids",input.getJSONArray("audios"))
+                            )
+                        )
+                    )
+                )
+            )
+            .put("recipe_id",input.getString("recipeId"))
+            .put("priority",input.getInt("priority"))
+            .put("protocol",new JSONObject()
+                .put("name","http")
+                .put("parameters",new JSONObject()
+                    .put("http_parameters", new JSONObject()
+                        .put("parameters",new JSONObject()
+                            .put("http_output_download_parameters",new JSONObject()
+                                .put("use_well_known_port",
+                                    (boolean) input.query("/urls/0/isWellKnownPort")
+                                        ? "yes" : "no")
+                                .put("use_ssl",
+                                    (boolean) input.query("/urls/0/isSsl")
+                                        ? "yes" : "no")
+                                .put("transfer_preset",""))
+                        )
+                    )
+                )
+            )
+            .put("content_uri","")
+            .put("session_operation_auth",new JSONObject()
+                .put("session_operation_auth_by_signature", new JSONObject()
+                    .put("token",input.getString("token"))
+                    .put("signature",input.getString("signature"))
+                )
+            )
+            .put("content_id",input.getString("contentId"))
+            .put("content_auth",new JSONObject()
+                .put("auth_type",input.query("/authTypes/http"))
+                .put("content_key_timeout",input.getInt("contentKeyTimeout"))
+                .put("service_id","nicovideo")
+                .put("service_user_id",input.getString("serviceUserId"))
+            )
+            .put("client_info",new JSONObject()
+                .put("player_id",input.getString("playerId"))
+            )
+        );
     }
 
     @Override

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioTrack.java
@@ -61,7 +61,7 @@ public class NicoAudioTrack extends DelegatedAudioTrack {
 
             log.debug("Starting NicoNico track from URL: {}", playbackUrl);
 
-            try (PersistentHttpStream stream = new HeartbeatingHttpStream(
+            try (HeartbeatingHttpStream stream = new HeartbeatingHttpStream(
                 httpInterface,
                 new URI(playbackUrl),
                 null,

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioTrack.java
@@ -25,10 +25,12 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * Audio track that handles processing NicoNico tracks.
@@ -40,9 +42,9 @@ public class NicoAudioTrack extends DelegatedAudioTrack {
 
     private final NicoAudioSourceManager sourceManager;
 
-    private String heartbeatURL;
-
-    private JsonBrowser info;
+    private String heartbeatUrl;
+    private int heartbeatIntervalMs;
+    private String initialHeartbeatPayload;
 
     /**
      * @param trackInfo     Track info
@@ -56,176 +58,130 @@ public class NicoAudioTrack extends DelegatedAudioTrack {
 
     @Override
     public void process(LocalAudioTrackExecutor localExecutor) throws Exception {
-
         try (HttpInterface httpInterface = sourceManager.getHttpInterface()) {
             String playbackUrl = loadPlaybackUrl(httpInterface);
 
             log.debug("Starting NicoNico track from URL: {}", playbackUrl);
 
-            try (PersistentHttpStream stream = new PersistentHttpStream(httpInterface, new URI(playbackUrl), null)) {
-                long heartbeat = info.get("session").get("keep_method").get("heartbeat").get("lifetime").asLong(120000) - 5000;
-                ScheduledFuture<?> heartbeatFuture = executorService.scheduleAtFixedRate(() -> {
-                    try {
-                        sendHeartbeat(httpInterface);
-                    } catch (Exception ex) {
-                        log.error("Heartbeat error!", ex);
-                        localExecutor.stop();
-                    }
-                },heartbeat,heartbeat, TimeUnit.MILLISECONDS);
+            try (PersistentHttpStream stream = new HeartbeatingHttpStream(
+                httpInterface,
+                new URI(playbackUrl),
+                null,
+                heartbeatUrl,
+                heartbeatIntervalMs,
+                initialHeartbeatPayload
+            )) {
                 processDelegate(new MpegAudioTrack(trackInfo, stream), localExecutor);
-                heartbeatFuture.cancel(false);
             }
         }
     }
 
     private JsonBrowser loadVideoMainPage(HttpInterface httpInterface) throws IOException {
-        HttpGet request = new HttpGet(trackInfo.uri);
-
-        try (CloseableHttpResponse response = httpInterface.execute(request)) {
-            int statusCode = response.getStatusLine().getStatusCode();
-            if (!HttpClientTools.isSuccessWithContent(statusCode)) {
-                throw new IOException("Unexpected status code from video main page: " + statusCode);
-            }
+        try (CloseableHttpResponse response = httpInterface.execute(new HttpGet(trackInfo.uri))) {
+            HttpClientTools.assertSuccessWithContent(response, "video main page");
 
             Document mainPage = Jsoup.parse(response.getEntity().getContent(), StandardCharsets.UTF_8.name(), "");
-            String watchdata = mainPage.getElementById("js-initial-watch-data").attr("data-api-data");
+            String watchData = mainPage.getElementById("js-initial-watch-data").attr("data-api-data");
 
-            return JsonBrowser.parse(watchdata).get("media").get("delivery").get("movie").get("session");
+            return JsonBrowser.parse(watchData).get("media").get("delivery").get("movie").get("session");
         }
     }
 
     private String loadPlaybackUrl(HttpInterface httpInterface) throws IOException {
-        JSONObject watchdata = processJSON(loadVideoMainPage(httpInterface));
+        JSONObject watchData = processJSON(loadVideoMainPage(httpInterface));
 
         HttpPost request = new HttpPost("https://api.dmc.nico/api/sessions?_format=json");
         request.addHeader("Host", "api.dmc.nico");
-        request.addHeader("Connection","keep-alive");
-        request.addHeader("Content-Type","application/json");
-        request.addHeader("Origin","https://www.nicovideo.jp");
-        request.setEntity(new StringEntity(watchdata.toString()));
+        request.addHeader("Connection", "keep-alive");
+        request.addHeader("Content-Type", "application/json");
+        request.addHeader("Origin", "https://www.nicovideo.jp");
+        request.setEntity(new StringEntity(watchData.toString()));
 
         try (CloseableHttpResponse response = httpInterface.execute(request)) {
             int statusCode = response.getStatusLine().getStatusCode();
+
             if (statusCode != HttpStatus.SC_CREATED) {
                 throw new IOException("Unexpected status code from playback parameters page: " + statusCode);
             }
 
-            info = JsonBrowser.parse(response.getEntity().getContent()).get("data");
-            heartbeatURL = "https://api.dmc.nico/api/sessions/" + info.get("session").get("id").text() + "?_format=json&_method=PUT";
-            log.debug("NicoNico heartbeat URL: {}", heartbeatURL);
-            return info.get("session").get("content_uri").text();
-        }
-    }
+            JsonBrowser info = JsonBrowser.parse(response.getEntity().getContent()).get("data");
+            JsonBrowser session = info.get("session");
 
-    private void sendHeartbeat(HttpInterface httpInterface) throws IOException {
-        HttpPost request = new HttpPost(heartbeatURL);
-        request.addHeader("Host", "api.dmc.nico");
-        request.addHeader("Connection","keep-alive");
-        request.addHeader("Content-Type","application/json");
-        request.addHeader("Origin","https://www.nicovideo.jp");
-        request.setEntity(new StringEntity(info.text()));
+            heartbeatUrl = "https://api.dmc.nico/api/sessions/" + session.get("id").text() + "?_format=json&_method=PUT";
+            heartbeatIntervalMs = session.get("keep_method").get("heartbeat").get("lifetime").asInt(120000) - 5000;
+            initialHeartbeatPayload = info.format();
 
-        try (CloseableHttpResponse response = httpInterface.execute(request)) {
-            int statusCode = response.getStatusLine().getStatusCode();
-            if (!HttpClientTools.isSuccessWithContent(statusCode)) {
-                throw new IOException("Unexpected status code from heartbeat page: " + statusCode);
-            }
-
-            info = JsonBrowser.parse(response.getEntity().getContent()).get("data");
+            return session.get("content_uri").text();
         }
     }
 
     private JSONObject processJSON(JsonBrowser input) {
-        JSONObject session = new JSONObject()
-            .put("content_type","movie")
-            .put("timing_constraint","unlimited")
-            .put("recipe_id",input.get("recipeId").text())
-            .put("content_id",input.get("contentId").text());
+        JSONObject lifetime = new JSONObject().put("lifetime", input.get("heartbeatLifetime").asLong(120000));
+        JSONObject heartbeat = new JSONObject().put("heartbeat", lifetime);
 
+        List<String> videos = input.get("videos").values().stream()
+            .map(JsonBrowser::text)
+            .collect(Collectors.toList());
 
-        JSONObject lifetime = new JSONObject()
-            .put("lifetime",input.get("heartbeatLifetime").asLong(120000));
+        List<String> audios = input.get("audios").values().stream()
+            .map(JsonBrowser::text)
+            .collect(Collectors.toList());
 
-        JSONObject heartbeat = new JSONObject()
-            .put("heartbeat",lifetime);
+        JSONObject srcIds = new JSONObject()
+            .put("video_src_ids", videos)
+            .put("audio_src_ids", audios);
 
-        session.put("keep_method",heartbeat);
+        JSONObject srcIdToMux = new JSONObject().put("src_id_to_mux", srcIds);
+        JSONArray array = new JSONArray().put(srcIdToMux);
+        JSONObject contentSrcIds = new JSONObject().put("content_src_ids", array);
+        JSONArray contentSrcIdSets = new JSONArray().put(contentSrcIds);
 
-        JSONArray videos = new JSONArray(input.get("videos").format());
-        JSONArray audios = new JSONArray(input.get("audios").format());
+        JsonBrowser url = input.get("urls").index(0);
+        boolean useWellKnownPort = url.get("isWellKnownPort").asBoolean(false);
+        boolean useSsl = url.get("isSsl").asBoolean(false);
 
-        JSONObject src_ids = new JSONObject()
-            .put("video_src_ids",videos)
-            .put("audio_src_ids",audios);
+        JSONObject httpDownloadParameters = new JSONObject()
+            .put("use_well_known_port", useWellKnownPort ? "yes" : "no")
+            .put("use_ssl", useSsl ? "yes" : "no");
 
-        JSONObject src_id_to_mux = new JSONObject()
-            .put("src_id_to_mux",src_ids);
+        JSONObject innerParameters = new JSONObject()
+            .put("http_output_download_parameters", httpDownloadParameters);
 
-        JSONArray array = new JSONArray()
-            .put(src_id_to_mux);
-
-        JSONObject content_src_ids = new JSONObject()
-            .put("content_src_ids",array);
-
-        JSONArray content_src_id_sets = new JSONArray()
-            .put(content_src_ids);
-
-        session.put("content_src_id_sets", content_src_id_sets);
-
-
-        JSONObject http_download_parameters = new JSONObject();
-
-        if(input.get("urls").index(0).get("isWellKnownPort").asBoolean(false))
-            http_download_parameters.put("use_well_known_port","yes");
-        else
-            http_download_parameters.put("use_well_known_port","no");
-
-        if(input.get("urls").index(0).get("isSsl").asBoolean(false))
-            http_download_parameters.put("use_ssl","yes");
-        else
-            http_download_parameters.put("use_ssl","no");
-
-        JSONObject inner_parameters = new JSONObject()
-            .put("http_output_download_parameters", http_download_parameters);
-
-        JSONObject http_parameters = new JSONObject()
-            .put("parameters", inner_parameters);
-
-        JSONObject outer_parameters = new JSONObject()
-            .put("http_parameters", http_parameters);
+        JSONObject httpParameters = new JSONObject().put("parameters", innerParameters);
+        JSONObject outerParameters = new JSONObject().put("http_parameters", httpParameters);
 
         JSONObject protocol = new JSONObject()
-            .put("name","http")
-            .put("parameters", outer_parameters);
+            .put("name", "http")
+            .put("parameters", outerParameters);
 
-        session.put("protocol",protocol);
+        JSONObject sessionOperationAuthBySignature = new JSONObject()
+            .put("token", input.get("token").text())
+            .put("signature", input.get("signature").text());
 
-        JSONObject session_operation_auth_by_signature = new JSONObject()
-            .put("token",input.get("token").text())
-            .put("signature",input.get("signature").text());
+        JSONObject sessionOperationAuth = new JSONObject()
+            .put("session_operation_auth_by_signature", sessionOperationAuthBySignature);
 
-        JSONObject session_operation_auth = new JSONObject()
-            .put("session_operation_auth_by_signature",session_operation_auth_by_signature);
+        JSONObject contentAuth = new JSONObject()
+            .put("auth_type", input.get("authTypes").get("http").text())
+            .put("content_key_timeout", input.get("contentKeyTimeout").asLong(120000))
+            .put("service_id", "nicovideo")
+            .put("service_user_id", input.get("serviceUserId").text());
 
-        session.put("session_operation_auth",session_operation_auth);
+        JSONObject clientInfo = new JSONObject().put("player_id", input.get("playerId").text());
 
+        JSONObject session = new JSONObject()
+            .put("content_type", "movie")
+            .put("timing_constraint", "unlimited")
+            .put("recipe_id", input.get("recipeId").text())
+            .put("content_id", input.get("contentId").text())
+            .put("keep_method", heartbeat)
+            .put("content_src_id_sets", contentSrcIdSets)
+            .put("protocol", protocol)
+            .put("session_operation_auth", sessionOperationAuth)
+            .put("content_auth", contentAuth)
+            .put("client_info", clientInfo);
 
-        JSONObject content_auth = new JSONObject()
-            .put("auth_type",input.get("authTypes").get("http").text())
-            .put("content_key_timeout",input.get("contentKeyTimeout").asLong(120000))
-            .put("service_id","nicovideo")
-            .put("service_user_id",input.get("serviceUserId").text());
-
-        session.put("content_auth", content_auth);
-
-
-        JSONObject client_info = new JSONObject()
-            .put("player_id",input.get("playerId").text());
-
-        session.put("client_info",client_info);
-
-        return new JSONObject()
-            .put("session",session);
+        return new JSONObject().put("session", session);
     }
 
     @Override

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/nico/NicoAudioTrack.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 public class NicoAudioTrack extends DelegatedAudioTrack {
     private static final Logger log = LoggerFactory.getLogger(NicoAudioTrack.class);
 
-    private static final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
+    private static final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
 
     private final NicoAudioSourceManager sourceManager;
 
@@ -61,7 +61,7 @@ public class NicoAudioTrack extends DelegatedAudioTrack {
             log.debug("Starting NicoNico track from URL: {}", playbackUrl);
 
             try (PersistentHttpStream stream = new PersistentHttpStream(httpInterface, new URI(playbackUrl), null)) {
-                long heartbeat = info.get("session").get("keep_method").get("heartbeat").get("lifetime").asLong(120000) - 60000;
+                long heartbeat = info.get("session").get("keep_method").get("heartbeat").get("lifetime").asLong(120000) - 1000;
                 ScheduledFuture<?> heartbeatFuture = executorService.scheduleAtFixedRate(() -> {
                     try {
                         sendHeartbeat(httpInterface);
@@ -86,7 +86,7 @@ public class NicoAudioTrack extends DelegatedAudioTrack {
             }
 
             Document mainPage = Jsoup.parse(response.getEntity().getContent(), StandardCharsets.UTF_8.name(), "");
-            String watchdata = mainPage.getElementById("js-initial-watch-data").attributes().get("data-api-data");
+            String watchdata = mainPage.getElementById("js-initial-watch-data").attr("data-api-data");
 
             return JsonBrowser.parse(watchdata).get("media").get("delivery").get("movie").get("session");
         }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/JsonBrowser.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/JsonBrowser.java
@@ -246,6 +246,22 @@ public class JsonBrowser {
         return defaultValue;
     }
 
+    public int asInt(int defaultValue) {
+        if (node != null) {
+            if (node.isNumber()) {
+                return node.numberValue().intValue();
+            } else if (node.isTextual()) {
+                try {
+                    return Integer.parseInt(node.textValue());
+                } catch (NumberFormatException ignored) {
+                    // Fall through to default value.
+                }
+            }
+        }
+
+        return defaultValue;
+    }
+
     public String safeText() {
         String text = text();
         return text != null ? text : "";

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/PersistentHttpStream.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/PersistentHttpStream.java
@@ -31,7 +31,7 @@ public class PersistentHttpStream extends SeekableInputStream implements AutoClo
 
     private static final long MAX_SKIP_DISTANCE = 512L * 1024L;
 
-    private final HttpInterface httpInterface;
+    protected final HttpInterface httpInterface;
     protected final URI contentUrl;
     private int lastStatusCode;
     private CloseableHttpResponse currentResponse;


### PR DESCRIPTION
NicoNico removed their [getflv API sometime this march](https://blog.nicovideo.jp/niconews/182541.html). I implemented [this blog post's solution](https://qiita.com/tor4kichi/items/91550a71119f3878bfba) and referenced [this library's JSON repackaging](https://github.com/niconicolibs/niconico.py).