### PR TITLE
[v1-legacy] Handle youtube `/live/` URLs.

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeLinkRouter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeLinkRouter.java
@@ -29,7 +29,8 @@ public class DefaultYoutubeLinkRouter implements YoutubeLinkRouter {
     new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + DOMAIN_REGEX + "/.*"), this::routeFromMainDomain),
     new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + SHORT_DOMAIN_REGEX + "/.*"), this::routeFromShortDomain),
     new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + DOMAIN_REGEX + "/embed/.*"), this::routeFromEmbed),
-    new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + DOMAIN_REGEX + "/shorts/.*"), this::routeFromShorts)
+    new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + DOMAIN_REGEX + "/shorts/.*"), this::routeFromShorts),
+    new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + DOMAIN_REGEX + "/live/.*"), this::routeFromShortPath)
   };
 
   @Override
@@ -116,6 +117,12 @@ public class DefaultYoutubeLinkRouter implements YoutubeLinkRouter {
   protected <T> T routeFromShorts(Routes<T> routes, String url) {
     UrlInfo urlInfo = getUrlInfo(url, true);
     return routeFromUrlWithVideoId(routes, urlInfo.path.substring(8), urlInfo);
+  }
+
+  protected <T> T routeFromShortPath(Routes<T> routes, String url) {
+    UrlInfo urlInfo = getUrlInfo(url, true);
+    String[] pathParts = urlInfo.path.split("/");
+    return routeFromUrlWithVideoId(routes, pathParts[pathParts.length - 1], urlInfo);
   }
 
   private static UrlInfo getUrlInfo(String url, boolean retryValidPart) {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeLinkRouter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeLinkRouter.java
@@ -30,7 +30,7 @@ public class DefaultYoutubeLinkRouter implements YoutubeLinkRouter {
     new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + SHORT_DOMAIN_REGEX + "/.*"), this::routeFromShortDomain),
     new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + DOMAIN_REGEX + "/embed/.*"), this::routeFromEmbed),
     new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + DOMAIN_REGEX + "/shorts/.*"), this::routeFromShorts),
-    new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + DOMAIN_REGEX + "/live/.*"), this::routeFromLivePath)
+    new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + DOMAIN_REGEX + "/live/.*"), this::routeFromLive)
   };
 
   @Override
@@ -119,7 +119,7 @@ public class DefaultYoutubeLinkRouter implements YoutubeLinkRouter {
     return routeFromUrlWithVideoId(routes, urlInfo.path.substring(8), urlInfo);
   }
 
-  protected <T> T routeFromLivePath(Routes<T> routes, String url) {
+  protected <T> T routeFromLive(Routes<T> routes, String url) {
     UrlInfo urlInfo = getUrlInfo(url, true);
     return routeFromUrlWithVideoId(routes, urlInfo.path.substring(6), urlInfo);
   }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeLinkRouter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeLinkRouter.java
@@ -30,7 +30,7 @@ public class DefaultYoutubeLinkRouter implements YoutubeLinkRouter {
     new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + SHORT_DOMAIN_REGEX + "/.*"), this::routeFromShortDomain),
     new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + DOMAIN_REGEX + "/embed/.*"), this::routeFromEmbed),
     new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + DOMAIN_REGEX + "/shorts/.*"), this::routeFromShorts),
-    new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + DOMAIN_REGEX + "/live/.*"), this::routeFromShortPath)
+    new Extractor(Pattern.compile("^" + PROTOCOL_REGEX + DOMAIN_REGEX + "/live/.*"), this::routeFromLivePath)
   };
 
   @Override
@@ -119,10 +119,9 @@ public class DefaultYoutubeLinkRouter implements YoutubeLinkRouter {
     return routeFromUrlWithVideoId(routes, urlInfo.path.substring(8), urlInfo);
   }
 
-  protected <T> T routeFromShortPath(Routes<T> routes, String url) {
+  protected <T> T routeFromLivePath(Routes<T> routes, String url) {
     UrlInfo urlInfo = getUrlInfo(url, true);
-    String[] pathParts = urlInfo.path.split("/");
-    return routeFromUrlWithVideoId(routes, pathParts[pathParts.length - 1], urlInfo);
+    return routeFromUrlWithVideoId(routes, urlInfo.path.substring(6), urlInfo);
   }
 
   private static UrlInfo getUrlInfo(String url, boolean retryValidPart) {


### PR DESCRIPTION
Adds an extractor for youtube URLs formatted as `https://youtube.com/live/<video id>`.

Identical to #53 but backported to V1.