### PR TITLE
fix: invalid search request (code 400)

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
@@ -9,7 +9,7 @@ public class YoutubeConstants {
 
     static final String INNERTUBE_ANDROID_API_KEY = "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w";
     static final String CLIENT_ANDROID_NAME = "ANDROID";
-    static final String CLIENT_ANDROID_VERSION = "17.29.34";
+    static final String CLIENT_ANDROID_VERSION = "18.06.35";
 
     static final String INNERTUBE_WEB_API_KEY = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
     static final String CLIENT_WEB_NAME = "WEB";


### PR DESCRIPTION
# Explain

This PR fixes this issue (`/search` endpoint): 
![image](https://github.com/lavalink-devs/lavaplayer/assets/16558115/06aa2890-a3ca-4912-ba73-eea3ce526574)

It looks like a new version of the YT backend has started rolling out to some regions.