### PR TITLE
bump sourceCompatibility to java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ features and fixes from [Walkyst's fork](https://github.com/Walkyst/lavaplayer-f
 
 **Please read the [FAQ](FAQ.md) in case of issues.**
 
+> [Note]
+> This fork requires Java 11 or newer. If you need Java 8 support you should update as java 8 was released 10 years ago.
+
 #### Maven package
 
 Replace `x.y.z` with the latest version

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,8 @@ subprojects {
     apply<MavenPublishPlugin>()
 
     configure<JavaPluginExtension> {
-        sourceCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     configure<PublishingExtension> {


### PR DESCRIPTION
out lavaplayer fork is not compatible with java 8. Therefore we should bump the sourceCompatibility to java 11 to reflect this. Our ci has been building with java 11 too