### PR TITLE
Switch to IOS youtube client instead of Android

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
@@ -36,7 +36,7 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
     public AudioPlaylist load(HttpInterface httpInterface, String playlistId, String selectedVideoId,
                               Function<AudioTrackInfo, AudioTrack> trackFactory) {
         HttpPost post = new HttpPost(BROWSE_URL);
-        YoutubeClientConfig clientConfig = YoutubeClientConfig.ANDROID.copy()
+        YoutubeClientConfig clientConfig = YoutubeClientConfig.IOS.copy()
             .withRootField("browseId", "VL" + playlistId)
             .setAttribute(httpInterface);
         StringEntity payload = new StringEntity(clientConfig.toJsonString(), "UTF-8");
@@ -90,7 +90,7 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
         // Also load the next pages, each result gives us a JSON with separate values for list html and next page loader html
         while (continuationsToken != null && ++loadCount < pageCount) {
             HttpPost post = new HttpPost(BROWSE_URL);
-            YoutubeClientConfig clientConfig = YoutubeClientConfig.ANDROID.copy()
+            YoutubeClientConfig clientConfig = YoutubeClientConfig.IOS.copy()
                 .withRootField("continuation", continuationsToken)
                 .setAttribute(httpInterface);
             StringEntity payload = new StringEntity(clientConfig.toJsonString(), "UTF-8");

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -213,14 +213,14 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
             clientConfig = YoutubeClientConfig.WEB.copy();
         } else if (infoStatus == InfoStatus.NON_EMBEDDABLE) {
             // Used when age restriction bypass failed, if we have valid auth then most likely this request will be successful
-            clientConfig = YoutubeClientConfig.ANDROID.copy()
+            clientConfig = YoutubeClientConfig.IOS.copy()
                 .withRootField("params", PLAYER_PARAMS);
         } else if (infoStatus == InfoStatus.REQUIRES_LOGIN) {
             // Age restriction bypass
             clientConfig = YoutubeClientConfig.TV_EMBEDDED.copy();
         } else {
             // Default payload from what we start trying to get required data
-            clientConfig = YoutubeClientConfig.ANDROID.copy()
+            clientConfig = YoutubeClientConfig.IOS.copy()
                 .withClientField("clientScreen", CLIENT_SCREEN_EMBED)
                 .withThirdPartyEmbedUrl(CLIENT_THIRD_PARTY_EMBED)
                 .withRootField("params", PLAYER_PARAMS);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAccessTokenTracker.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAccessTokenTracker.java
@@ -229,7 +229,7 @@ public class YoutubeAccessTokenTracker {
         try (HttpInterface httpInterface = httpInterfaceManager.getInterface()) {
             httpInterface.getContext().setAttribute(TOKEN_FETCH_CONTEXT_ATTRIBUTE, true);
 
-            YoutubeClientConfig clientConfig = YoutubeClientConfig.ANDROID.copy().setAttribute(httpInterface);
+            YoutubeClientConfig clientConfig = YoutubeClientConfig.IOS.copy().setAttribute(httpInterface);
             HttpPost visitorIdPost = new HttpPost(VISITOR_ID_URL);
             StringEntity visitorIdPayload = new StringEntity(clientConfig.toJsonString(), "UTF-8");
             visitorIdPost.setEntity(visitorIdPayload);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeClientConfig.java
@@ -8,14 +8,13 @@ import static com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeHttpContext
 import static com.sedmelluq.discord.lavaplayer.source.youtube.YoutubePayloadHelper.putOnceAndJoin;
 
 public class YoutubeClientConfig extends JSONObject {
-    public static final AndroidVersion DEFAULT_ANDROID_VERSION = AndroidVersion.ANDROID_11;
 
-    public static YoutubeClientConfig ANDROID = new YoutubeClientConfig()
-        .withApiKey(INNERTUBE_ANDROID_API_KEY)
-        .withUserAgent(String.format("com.google.android.youtube/%s (Linux; U; Android %s) gzip", CLIENT_ANDROID_VERSION, DEFAULT_ANDROID_VERSION.getOsVersion()))
-        .withClientName(CLIENT_ANDROID_NAME)
-        .withClientField("clientVersion", CLIENT_ANDROID_VERSION)
-        .withClientField("androidSdkVersion", DEFAULT_ANDROID_VERSION.getSdkVersion())
+    public static YoutubeClientConfig IOS = new YoutubeClientConfig()
+        .withApiKey(INNERTUBE_IOS_API_KEY)
+        .withUserAgent("com.google.ios.youtube/19.09.3 (iPhone14,3; U; CPU iOS 15_6 like Mac OS X)")
+        .withClientName(CLIENT_IOS_NAME)
+        .withClientField("clientVersion", CLIENT_IOS_VERSION)
+        .withClientField("deviceModel", "iPhone14,3")
         //.withClientField("osName", "Android")
         //.withClientField("osVersion", DEFAULT_ANDROID_VERSION.getOsVersion())
         .withClientDefaultScreenParameters();
@@ -135,26 +134,5 @@ public class YoutubeClientConfig extends JSONObject {
 
     public String toJsonString() {
         return root.toString();
-    }
-
-    public enum AndroidVersion {
-        // https://apilevels.com/
-        ANDROID_11("11", 30);
-
-        private final String osVersion;
-        private final int sdkVersion;
-
-        AndroidVersion(String osVersion, int sdkVersion) {
-            this.osVersion = osVersion;
-            this.sdkVersion = sdkVersion;
-        }
-
-        public String getOsVersion() {
-            return osVersion;
-        }
-
-        public int getSdkVersion() {
-            return sdkVersion;
-        }
     }
 }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeConstants.java
@@ -7,9 +7,9 @@ public class YoutubeConstants {
     static final String YOUTUBE_API_ORIGIN = "https://youtubei.googleapis.com";
     static final String BASE_URL = YOUTUBE_API_ORIGIN + "/youtubei/v1";
 
-    static final String INNERTUBE_ANDROID_API_KEY = "AIzaSyA8eiZmM1FaDVjRy-df2KTyQ_vz_yYM39w";
-    static final String CLIENT_ANDROID_NAME = "ANDROID";
-    static final String CLIENT_ANDROID_VERSION = "18.06.35";
+    static final String INNERTUBE_IOS_API_KEY = "AIzaSyB-63vPrdThhKuerbB2N_l7Kwwcxj6yUAc";
+    static final String CLIENT_IOS_NAME = "IOS";
+    static final String CLIENT_IOS_VERSION = "19.09.3";
 
     static final String INNERTUBE_WEB_API_KEY = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
     static final String CLIENT_WEB_NAME = "WEB";
@@ -24,7 +24,7 @@ public class YoutubeConstants {
     static final String PLAYER_PARAMS = "CgIQBg";
     static final String SEARCH_PARAMS = "EgIQAUICCAE=";
 
-    static final String SEARCH_URL = BASE_URL + "/search?key=" + INNERTUBE_ANDROID_API_KEY;
+    static final String SEARCH_URL = BASE_URL + "/search?key=" + INNERTUBE_IOS_API_KEY;
     static final String PLAYER_URL = BASE_URL + "/player";
     static final String BROWSE_URL = BASE_URL + "/browse";
     static final String NEXT_URL = BASE_URL + "/next";

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
@@ -78,7 +78,7 @@ public class YoutubeHttpContextFilter implements HttpContextFilter {
         } else {
             try {
                 URI uri = new URIBuilder(request.getURI())
-                    .setParameter("key", YoutubeConstants.INNERTUBE_ANDROID_API_KEY)
+                    .setParameter("key", YoutubeConstants.INNERTUBE_IOS_API_KEY)
                     .build();
 
                 if (request instanceof HttpRequestBase) {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeMixProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeMixProvider.java
@@ -44,7 +44,7 @@ public class YoutubeMixProvider implements YoutubeMixLoader {
         List<AudioTrack> tracks = new ArrayList<>();
 
         HttpPost post = new HttpPost(NEXT_URL);
-        YoutubeClientConfig clientConfig = YoutubeClientConfig.ANDROID.copy()
+        YoutubeClientConfig clientConfig = YoutubeClientConfig.IOS.copy()
             .withRootField("videoId", selectedVideoId)
             .withRootField("playlistId", mixId)
             .setAttribute(httpInterface);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
@@ -52,7 +52,7 @@ public class YoutubeSearchProvider implements YoutubeSearchResultLoader {
 
         try (HttpInterface httpInterface = httpInterfaceManager.getInterface()) {
             HttpPost post = new HttpPost(SEARCH_URL);
-            YoutubeClientConfig clientConfig = YoutubeClientConfig.ANDROID.copy()
+            YoutubeClientConfig clientConfig = YoutubeClientConfig.IOS.copy()
                 .withRootField("query", query)
                 .withRootField("params", SEARCH_PARAMS)
                 .setAttribute(httpInterface);


### PR DESCRIPTION
This PR is meant to fix https://github.com/lavalink-devs/Lavalink/issues/1030 where YouTube started blocking the Android Client in an A/B way, but now it's affecting more people.

The workaround provided switches to the iOS client entirely, which seems to fix the issue on my side.

I, however, am not sure if switching directly from Android to iOS will have significant disadvantages in the future. Given the fact that YouTube targeted Android Mobile App frontends like Revanced with their update, **maybe the iOS client is more future proof**, but that's just an assumption.

 I encourage testing in other environments to confirm the fix's effectiveness and identify any potential side effects.