### PR TITLE
[v1-legacy] Use WEB client, add 403 retry (Fix "Video returned by Youtube is not what was requested")

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -213,14 +213,14 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
       clientConfig = YoutubeClientConfig.WEB.copy();
     } else if (infoStatus == InfoStatus.NON_EMBEDDABLE) {
       // Used when age restriction bypass failed, if we have valid auth then most likely this request will be successful
-      clientConfig = YoutubeClientConfig.ANDROID.copy()
+      clientConfig = YoutubeClientConfig.WEB.copy()
         .withRootField("params", PLAYER_PARAMS);
     } else if (infoStatus == InfoStatus.REQUIRES_LOGIN) {
       // Age restriction bypass
       clientConfig = YoutubeClientConfig.TV_EMBEDDED.copy();
     } else {
       // Default payload from what we start trying to get required data
-      clientConfig = YoutubeClientConfig.ANDROID.copy()
+      clientConfig = YoutubeClientConfig.WEB.copy()
         .withClientField("clientScreen", CLIENT_SCREEN_EMBED)
         .withThirdPartyEmbedUrl(CLIENT_THIRD_PARTY_EMBED)
         .withRootField("params", PLAYER_PARAMS);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAccessTokenTracker.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAccessTokenTracker.java
@@ -229,7 +229,7 @@ public class YoutubeAccessTokenTracker {
     try (HttpInterface httpInterface = httpInterfaceManager.getInterface()) {
       httpInterface.getContext().setAttribute(TOKEN_FETCH_CONTEXT_ATTRIBUTE, true);
 
-      YoutubeClientConfig clientConfig = YoutubeClientConfig.ANDROID.copy().setAttribute(httpInterface);
+      YoutubeClientConfig clientConfig = YoutubeClientConfig.WEB.copy().setAttribute(httpInterface);
       HttpPost visitorIdPost = new HttpPost(VISITOR_ID_URL);
       StringEntity visitorIdPayload = new StringEntity(clientConfig.toJsonString(), "UTF-8");
       visitorIdPost.setEntity(visitorIdPayload);


### PR DESCRIPTION
Should fix https://github.com/lavalink-devs/Lavalink/issues/1030 by switching from `ANDROID` client to `WEB`.

To minimize the chances of encountering a 403 due to the odd invalid cipher resolving, I've implemented a basic 403 retry mechanism that will aim to fetch a new stream URL up to 3 times before throwing.