### PR TITLE
Use WEB client, add 403 retry (Fix "Video returned by Youtube is not what was requested")

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
@@ -36,6 +36,8 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
     public AudioPlaylist load(HttpInterface httpInterface, String playlistId, String selectedVideoId,
                               Function<AudioTrackInfo, AudioTrack> trackFactory) {
         HttpPost post = new HttpPost(BROWSE_URL);
+        // TODO: Keep an eye on this.
+        // Can't drop in WEB as it yields no results.
         YoutubeClientConfig clientConfig = YoutubeClientConfig.ANDROID.copy()
             .withRootField("browseId", "VL" + playlistId)
             .setAttribute(httpInterface);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAccessTokenTracker.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAccessTokenTracker.java
@@ -229,7 +229,7 @@ public class YoutubeAccessTokenTracker {
         try (HttpInterface httpInterface = httpInterfaceManager.getInterface()) {
             httpInterface.getContext().setAttribute(TOKEN_FETCH_CONTEXT_ATTRIBUTE, true);
 
-            YoutubeClientConfig clientConfig = YoutubeClientConfig.ANDROID.copy().setAttribute(httpInterface);
+            YoutubeClientConfig clientConfig = YoutubeClientConfig.WEB.copy().setAttribute(httpInterface);
             HttpPost visitorIdPost = new HttpPost(VISITOR_ID_URL);
             StringEntity visitorIdPayload = new StringEntity(clientConfig.toJsonString(), "UTF-8");
             visitorIdPost.setEntity(visitorIdPayload);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeMixProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeMixProvider.java
@@ -44,6 +44,8 @@ public class YoutubeMixProvider implements YoutubeMixLoader {
         List<AudioTrack> tracks = new ArrayList<>();
 
         HttpPost post = new HttpPost(NEXT_URL);
+        // TODO: Keep an eye on this.
+        // Can't drop in WEB as it yields no results.
         YoutubeClientConfig clientConfig = YoutubeClientConfig.ANDROID.copy()
             .withRootField("videoId", selectedVideoId)
             .withRootField("playlistId", mixId)

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
@@ -52,7 +52,9 @@ public class YoutubeSearchProvider implements YoutubeSearchResultLoader {
 
         try (HttpInterface httpInterface = httpInterfaceManager.getInterface()) {
             HttpPost post = new HttpPost(SEARCH_URL);
-            YoutubeClientConfig clientConfig = YoutubeClientConfig.WEB.copy()
+            // TODO: Keep an eye on this.
+            // Can't drop in WEB as it yields no results.
+            YoutubeClientConfig clientConfig = YoutubeClientConfig.ANDROID.copy()
                 .withRootField("query", query)
                 .withRootField("params", SEARCH_PARAMS)
                 .setAttribute(httpInterface);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
@@ -52,7 +52,7 @@ public class YoutubeSearchProvider implements YoutubeSearchResultLoader {
 
         try (HttpInterface httpInterface = httpInterfaceManager.getInterface()) {
             HttpPost post = new HttpPost(SEARCH_URL);
-            YoutubeClientConfig clientConfig = YoutubeClientConfig.ANDROID.copy()
+            YoutubeClientConfig clientConfig = YoutubeClientConfig.WEB.copy()
                 .withRootField("query", query)
                 .withRootField("params", SEARCH_PARAMS)
                 .setAttribute(httpInterface);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeTrackDetailsLoader.java
@@ -3,5 +3,18 @@ package com.sedmelluq.discord.lavaplayer.source.youtube;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
 
 public interface YoutubeTrackDetailsLoader {
-    YoutubeTrackDetails loadDetails(HttpInterface httpInterface, String videoId, boolean requireFormats, YoutubeAudioSourceManager sourceManager);
+    YoutubeTrackDetails loadDetails(HttpInterface httpInterface,
+                                    String videoId,
+                                    boolean requireFormats,
+                                    YoutubeAudioSourceManager sourceManager);
+
+    default YoutubeTrackDetails loadDetails(HttpInterface httpInterface,
+                                    String videoId,
+                                    boolean requireFormats,
+                                    YoutubeAudioSourceManager sourceManager,
+                                    YoutubeClientConfig clientOverride) {
+        // Implemented this way to be non-breaking. clientOverride will be ignored for implementations
+        // that don't implement this override.
+        return loadDetails(httpInterface, videoId, requireFormats, sourceManager);
+    }
 }


### PR DESCRIPTION
Should fix https://github.com/lavalink-devs/Lavalink/issues/1030 by switching from `ANDROID` client to `WEB`.

To minimize the chances of encountering a 403 due to the odd invalid cipher resolving, I've implemented a basic 403 retry mechanism that will aim to fetch a new stream URL up to 3 times before throwing.