### PR TITLE
Add potential thread leak fix

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
@@ -241,9 +241,13 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
     private void handleTerminator(InternalAudioTrack track) {
         synchronized (trackSwitchLock) {
             if (activeTrack == track) {
-                activeTrack = null;
-
-                dispatchEvent(new TrackEndEvent(this, track, track.getActiveExecutor().failedBeforeLoad() ? LOAD_FAILED : FINISHED));
+                InternalAudioTrack oldTrack = activeTrack;
+                try {
+                    activeTrack = null;
+                    dispatchEvent(new TrackEndEvent(this, track, track.getActiveExecutor().failedBeforeLoad() ? LOAD_FAILED : FINISHED));
+                } finally {
+                    oldTrack.stop();
+                }
             }
         }
     }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/track/playback/AudioTrackExecutor.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/track/playback/AudioTrackExecutor.java
@@ -21,7 +21,8 @@ public interface AudioTrackExecutor extends AudioFrameProvider {
     void execute(TrackStateListener listener);
 
     /**
-     * Stop playing the track, terminating the thread that is filling the frame buffer.
+     * Stop playing the track, terminating the thread that is filling the frame buffer. Subsequent playback requires
+     *  a new executor.
      */
     void stop();
 


### PR DESCRIPTION
This PR changes the lifecycle of `LocalAudioTrackExecutor` such that it is completely disposed of when the track ends. This appears to resolve a suspected race condition that causes a thread and memory leak.

I am still testing these changes. 