### PR TITLE
[v1-legacy] Fix one instance of invalid OGG Opus duration extraction

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/ogg/opus/OggOpusCodecHandler.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/ogg/opus/OggOpusCodecHandler.java
@@ -49,12 +49,13 @@ public class OggOpusCodecHandler implements OggCodecHandler {
   public OggMetadata loadMetadata(OggPacketInputStream stream, DirectBufferStreamBroker broker) throws IOException {
     ByteBuffer firstPacket = broker.getBuffer();
     verifyFirstPacket(firstPacket);
+    int sampleRate = getSampleRate(firstPacket);
 
     loadCommentsHeader(stream, broker, false);
 
     return new OggMetadata(
       parseTags(broker.getBuffer(), broker.isTruncated()),
-      detectLength(stream, getSampleRate(firstPacket))
+      detectLength(stream, sampleRate)
     );
   }
 


### PR DESCRIPTION
Fixes an issue where the retrieved `sampleRate` value was an arbitrary number, not indicative of the actual sample rate. This lead to invalid duration values.

This seems to be caused by an error in the `firstPacket` buffer contents after reading comments and tags, so it's read before any of that occurs.

This has been tested and appears to work correctly, yielding the correct value of `48000` in my test files.

This commit has also been tested and is inline with the ID header specification found at https://wiki.xiph.org/OggOpus#ID_Header