### PR TITLE
Support ISRC metadata in MP3, OGG and Matroska files

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaContainerProbe.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaContainerProbe.java
@@ -4,10 +4,12 @@ import com.sedmelluq.discord.lavaplayer.container.MediaContainerDetectionResult;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerHints;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.container.matroska.format.MatroskaFileTrack;
+import com.sedmelluq.discord.lavaplayer.tools.DataFormatTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.SeekableInputStream;
 import com.sedmelluq.discord.lavaplayer.track.AudioReference;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
+import com.sedmelluq.discord.lavaplayer.track.info.AudioTrackInfoBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,14 +61,11 @@ public class MatroskaContainerProbe implements MediaContainerProbe {
             return unsupportedFormat(this, "No supported audio tracks present in the file.");
         }
 
-        String title = file.getTitle();
-        String actualTitle = title == null || title.isEmpty() ? UNKNOWN_TITLE : title;
+        String title = DataFormatTools.defaultOnNull(file.getTitle(), UNKNOWN_TITLE);
+        String artist = DataFormatTools.defaultOnNull(file.getArtist(), UNKNOWN_ARTIST);
 
-        String artist = file.getArtist();
-        String actualArtist = artist == null || artist.isEmpty() ? UNKNOWN_ARTIST : artist;
-
-        return supportedFormat(this, null, new AudioTrackInfo(actualTitle, actualArtist,
-            (long) file.getDuration(), reference.identifier, false, reference.identifier, null, null));
+        return supportedFormat(this, null, new AudioTrackInfo(title, artist,
+            (long) file.getDuration(), reference.identifier, false, reference.identifier, null, file.getIsrc()));
     }
 
     private boolean hasSupportedAudioTrack(MatroskaStreamingFile file) {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaStreamingFile.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaStreamingFile.java
@@ -399,7 +399,7 @@ public class MatroskaStreamingFile {
                 duration = reader.asDouble(child);
             } else if (child.is(MatroskaElementType.TimecodeScale)) {
                 timecodeScale = reader.asLong(child);
-            } else if (child.is(MatroskaElementType.Title)) {
+            } else if (child.is(MatroskaElementType.Title) && title == null) {
                 title = reader.asString(child);
             }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaStreamingFile.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaStreamingFile.java
@@ -451,7 +451,10 @@ public class MatroskaStreamingFile {
             if (child.is(MatroskaElementType.TagName)) {
                 tagName = reader.asString(child);
             } else if (child.is(MatroskaElementType.TagString)) {
-                if ("artist".equalsIgnoreCase(tagName)) {
+                // https://www.matroska.org/technical/tagging.html
+                if ("title".equals(tagName) && title == null) {
+                    title = reader.asString(child);
+                } else if ("artist".equalsIgnoreCase(tagName)) {
                     artist = reader.asString(child);
                 } else if ("isrc".equals(tagName)) {
                     isrc = reader.asString(child);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaStreamingFile.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaStreamingFile.java
@@ -18,6 +18,7 @@ public class MatroskaStreamingFile {
 
     private String title;
     private String artist;
+    private String isrc;
 
     private long timecodeScale = 1000000;
     private double duration;
@@ -49,11 +50,15 @@ public class MatroskaStreamingFile {
      * @return The title for this file.
      */
     public String getTitle() {
-        return title;
+        return title != null && title.isEmpty() ? null : title;
     }
 
     public String getArtist() {
-        return artist;
+        return artist != null && artist.isEmpty() ? null : artist;
+    }
+
+    public String getIsrc() {
+        return isrc != null && isrc.isEmpty() ? null : isrc;
     }
 
     /**
@@ -448,6 +453,8 @@ public class MatroskaStreamingFile {
             } else if (child.is(MatroskaElementType.TagString)) {
                 if ("artist".equalsIgnoreCase(tagName)) {
                     artist = reader.asString(child);
+                } else if ("isrc".equals(tagName)) {
+                    isrc = reader.asString(child);
                 }
             }
         }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaStreamingFile.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaStreamingFile.java
@@ -452,11 +452,11 @@ public class MatroskaStreamingFile {
                 tagName = reader.asString(child);
             } else if (child.is(MatroskaElementType.TagString)) {
                 // https://www.matroska.org/technical/tagging.html
-                if ("title".equals(tagName) && title == null) {
+                if ("title".equalsIgnoreCase(tagName) && title == null) {
                     title = reader.asString(child);
                 } else if ("artist".equalsIgnoreCase(tagName)) {
                     artist = reader.asString(child);
-                } else if ("isrc".equals(tagName)) {
+                } else if ("isrc".equalsIgnoreCase(tagName)) {
                     isrc = reader.asString(child);
                 }
             }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/mp3/Mp3TrackProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/mp3/Mp3TrackProvider.java
@@ -31,8 +31,9 @@ public class Mp3TrackProvider implements AudioTrackInfoProvider {
 
     private static final String TITLE_TAG = "TIT2";
     private static final String ARTIST_TAG = "TPE1";
+    private static final String ISRC_TAG = "TSRC";
 
-    private static final List<String> knownTextExtensions = Arrays.asList(TITLE_TAG, ARTIST_TAG);
+    private static final List<String> knownTextExtensions = Arrays.asList(TITLE_TAG, ARTIST_TAG, ISRC_TAG);
 
     private final AudioProcessingContext context;
     private final SeekableInputStream inputStream;
@@ -369,7 +370,7 @@ public class Mp3TrackProvider implements AudioTrackInfoProvider {
 
     @Override
     public String getISRC() {
-        return null;
+        return getIdv3Tag(ISRC_TAG);
     }
 
     private static class FrameHeader {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/ogg/OggMetadata.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/ogg/OggMetadata.java
@@ -14,6 +14,7 @@ public class OggMetadata implements AudioTrackInfoProvider {
 
     private static final String TITLE_FIELD = "TITLE";
     private static final String ARTIST_FIELD = "ARTIST";
+    private static final String ISRC_FIELD = "ISRC";
 
     private final Map<String, String> tags;
     private final Long length;
@@ -58,6 +59,6 @@ public class OggMetadata implements AudioTrackInfoProvider {
 
     @Override
     public String getISRC() {
-        return null;
+        return tags.get(ISRC_FIELD);
     }
 }


### PR DESCRIPTION
Adds support for extracting ISRC out of MP3 ID3v2 tags, OGG tags and Matroska tags.
Also adds support for extracting Matroska track title from tags as https://www.matroska.org/technical/tagging.html suggests this can be the case.