### PR TITLE
Remove embedded AAC decoder

### DIFF
--- a/main/build.gradle.kts
+++ b/main/build.gradle.kts
@@ -16,7 +16,6 @@ base {
 dependencies {
     api(projects.common)
     implementation(projects.nativesPublish)
-    implementation(libs.jaadec.fork)
     implementation(libs.rhino.engine)
     implementation(libs.slf4j)
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/common/AacPacketRouter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/common/AacPacketRouter.java
@@ -5,71 +5,58 @@ import com.sedmelluq.discord.lavaplayer.filter.AudioPipelineFactory;
 import com.sedmelluq.discord.lavaplayer.filter.PcmFormat;
 import com.sedmelluq.discord.lavaplayer.natives.aac.AacDecoder;
 import com.sedmelluq.discord.lavaplayer.track.playback.AudioProcessingContext;
-import net.sourceforge.jaad.aac.Decoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ShortBuffer;
+import java.util.function.Consumer;
 
 public class AacPacketRouter {
     private static final Logger log = LoggerFactory.getLogger(AacPacketRouter.class);
 
     private final AudioProcessingContext context;
+    private final Consumer<AacDecoder> decoderConfigurer;
 
     private Long initialRequestedTimecode;
     private Long initialProvidedTimecode;
     private AudioPipeline downstream;
     private ShortBuffer outputBuffer;
 
-    public AacDecoder nativeDecoder;
-    public Decoder embeddedDecoder;
+    public AacDecoder decoder;
 
-    public AacPacketRouter(AudioProcessingContext context) {
+    public AacPacketRouter(AudioProcessingContext context, Consumer<AacDecoder> decoderConfigurer) {
         this.context = context;
+        this.decoderConfigurer = decoderConfigurer;
     }
 
     public void processInput(ByteBuffer inputBuffer) throws InterruptedException {
-        if (embeddedDecoder == null) {
-            nativeDecoder.fill(inputBuffer);
+        if (decoder == null) {
+            decoder = new AacDecoder();
+            decoderConfigurer.accept(decoder);
+        }
 
-            if (downstream == null) {
-                log.debug("Using native decoder");
-                AacDecoder.StreamInfo streamInfo = nativeDecoder.resolveStreamInfo();
+        decoder.fill(inputBuffer);
 
-                if (streamInfo != null) {
-                    downstream = AudioPipelineFactory.create(context, new PcmFormat(streamInfo.channels, streamInfo.sampleRate));
-                    outputBuffer = ByteBuffer.allocateDirect(2 * streamInfo.frameSize * streamInfo.channels)
-                        .order(ByteOrder.nativeOrder()).asShortBuffer();
+        if (downstream == null) {
+            AacDecoder.StreamInfo streamInfo = decoder.resolveStreamInfo();
 
-                    if (initialRequestedTimecode != null) {
-                        downstream.seekPerformed(initialRequestedTimecode, initialProvidedTimecode);
-                    }
-                }
-            }
-
-            if (downstream != null) {
-                while (nativeDecoder.decode(outputBuffer, false)) {
-                    downstream.process(outputBuffer);
-                    outputBuffer.clear();
-                }
-            }
-        } else {
-            if (downstream == null) {
-                log.debug("Using embedded decoder");
-                downstream = AudioPipelineFactory.create(context, new PcmFormat(
-                    embeddedDecoder.getAudioFormat().getChannels(),
-                    (int) embeddedDecoder.getAudioFormat().getSampleRate()
-                ));
+            if (streamInfo != null) {
+                downstream = AudioPipelineFactory.create(context, new PcmFormat(streamInfo.channels, streamInfo.sampleRate));
+                outputBuffer = ByteBuffer.allocateDirect(2 * streamInfo.frameSize * streamInfo.channels)
+                    .order(ByteOrder.nativeOrder()).asShortBuffer();
 
                 if (initialRequestedTimecode != null) {
                     downstream.seekPerformed(initialRequestedTimecode, initialProvidedTimecode);
                 }
             }
+        }
 
-            if (downstream != null) {
-                downstream.process(embeddedDecoder.decodeFrame(inputBuffer.array()));
+        if (downstream != null) {
+            while (decoder.decode(outputBuffer, false)) {
+                downstream.process(outputBuffer);
+                outputBuffer.clear();
             }
         }
     }
@@ -82,17 +69,15 @@ public class AacPacketRouter {
             this.initialProvidedTimecode = providedTimecode;
         }
 
-        if (nativeDecoder != null) {
-            nativeDecoder.close();
-            nativeDecoder = null;
-        } else if (embeddedDecoder != null) {
-            embeddedDecoder = null;
+        if (decoder != null) {
+            decoder.close();
+            decoder = null;
         }
     }
 
     public void flush() throws InterruptedException {
         if (downstream != null) {
-            while (nativeDecoder.decode(outputBuffer, true)) {
+            while (decoder.decode(outputBuffer, true)) {
                 downstream.process(outputBuffer);
                 outputBuffer.clear();
             }
@@ -105,10 +90,8 @@ public class AacPacketRouter {
                 downstream.close();
             }
         } finally {
-            if (nativeDecoder != null) {
-                nativeDecoder.close();
-            } else if (embeddedDecoder != null) {
-                embeddedDecoder = null;
+            if (decoder != null) {
+                decoder.close();
             }
         }
     }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaContainerProbe.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaContainerProbe.java
@@ -9,7 +9,6 @@ import com.sedmelluq.discord.lavaplayer.tools.io.SeekableInputStream;
 import com.sedmelluq.discord.lavaplayer.track.AudioReference;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackInfo;
-import com.sedmelluq.discord.lavaplayer.track.info.AudioTrackInfoBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -50,7 +50,6 @@ fun VersionCatalogBuilder.common() {
 
 fun VersionCatalogBuilder.others() {
     library("ibxm-fork", "com.github.walkyst", "ibxm-fork").version("a75")
-    library("jaadec-fork", "com.github.walkyst", "JAADec-fork").version("0.1.3")
     library("rhino-engine", "org.mozilla", "rhino-engine").version("1.7.14")
 }
 


### PR DESCRIPTION
Removes the embedded AAC decoder (JAAD) now that the native one should hopefully be more robust and provide the same level of compatibility, if not better, than the embedded decoder, along with better performance.