### PR TITLE
MP3: Reduce IDv3 scan buffer array copying and limit reading to up to 3 IDv3 blocks

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/mp3/Mp3TrackProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/mp3/Mp3TrackProvider.java
@@ -194,14 +194,13 @@ public class Mp3TrackProvider implements AudioTrackInfoProvider {
     private void skipIdv3Tags() throws IOException {
         byte[] lastTagHeader = new byte[4];
 
-        while (true) {
-            System.arraycopy(tagHeaderBuffer, 0, lastTagHeader, 0, 4);
-            dataInput.readFully(tagHeaderBuffer, 0, 3);
+        for (int reads = 0; reads < 3; reads++) {
+            dataInput.readFully(lastTagHeader, 0, 3);
 
             for (int i = 0; i < 3; i++) {
-                if (tagHeaderBuffer[i] != IDV3_TAG[i]) {
-                    frameReader.appendToScanBuffer(tagHeaderBuffer, 0, 3);
+                if (lastTagHeader[i] != IDV3_TAG[i]) {
                     System.arraycopy(lastTagHeader, 0, tagHeaderBuffer, 0, 4);
+                    frameReader.appendToScanBuffer(tagHeaderBuffer, 0, 3);
                     return;
                 }
             }
@@ -227,6 +226,8 @@ public class Mp3TrackProvider implements AudioTrackInfoProvider {
 
             inputStream.seek(tagsEndPosition);
         }
+
+        throw new RuntimeException("Read more than 3 IDv3 blocks, file is possibly invalid");
     }
 
     private int readSyncProofInteger() throws IOException {


### PR DESCRIPTION
Reduces array copying whilst scanning for IDv3 blocks within an MP3 frame, instead reading directly to a temporary buffer and then copying the result once into a tag header buffer.

Also restricts reading to up to 3 IDv3 blocks before considering a file as possibly invalid. Ideally, MP3 files should only contain a single IDv3 block anyway.
