### PR TITLE
Distinguish between inner and outer M3U(8) playlists.

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/stream/M3uStreamSegmentUrlProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/stream/M3uStreamSegmentUrlProvider.java
@@ -170,7 +170,7 @@ public abstract class M3uStreamSegmentUrlProvider {
                 }
 
                 streamInfoLine = null;
-            } else if (line.isDirective() && "EXT-X-STREAM-INF".equals(line.directiveName)) {
+            } else if (line.isDirective() && ("EXT-X-STREAM-INF".equals(line.directiveName)  || "EXTINF".equals(line.directiveName))) {
                 streamInfoLine = line;
             }
         }


### PR DESCRIPTION
Fixes an issue where some playlists cannot be loaded if a direct link to an inner playlist is provided.
![image](https://github.com/lavalink-devs/lavaplayer/assets/15076404/2ec9a504-bba2-47a2-848d-2dfa0f0b82ea)
