### PR TITLE
Force reading of title, artist and isrc as UTF-8 for Matroska files

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaStreamingFile.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaStreamingFile.java
@@ -5,6 +5,7 @@ import com.sedmelluq.discord.lavaplayer.tools.io.SeekableInputStream;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -400,7 +401,7 @@ public class MatroskaStreamingFile {
             } else if (child.is(MatroskaElementType.TimecodeScale)) {
                 timecodeScale = reader.asLong(child);
             } else if (child.is(MatroskaElementType.Title) && title == null) {
-                title = reader.asString(child);
+                title = reader.asString(child, StandardCharsets.UTF_8);
             }
 
             reader.skip(child);
@@ -453,11 +454,12 @@ public class MatroskaStreamingFile {
             } else if (child.is(MatroskaElementType.TagString)) {
                 // https://www.matroska.org/technical/tagging.html
                 if ("title".equalsIgnoreCase(tagName) && title == null) {
-                    title = reader.asString(child);
+                    title = reader.asString(child, StandardCharsets.UTF_8);
                 } else if ("artist".equalsIgnoreCase(tagName)) {
-                    artist = reader.asString(child);
+                    artist = reader.asString(child, StandardCharsets.UTF_8);
                 } else if ("isrc".equalsIgnoreCase(tagName)) {
-                    isrc = reader.asString(child);
+                    // probably not necessary to force a charset here
+                    isrc = reader.asString(child, StandardCharsets.UTF_8);
                 }
             }
         }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaStreamingFile.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaStreamingFile.java
@@ -463,5 +463,7 @@ public class MatroskaStreamingFile {
                 }
             }
         }
+
+        reader.skip(child);
     }
 }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/format/MatroskaFileReader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/format/MatroskaFileReader.java
@@ -5,6 +5,7 @@ import com.sedmelluq.discord.lavaplayer.tools.io.SeekableInputStream;
 import java.io.DataInput;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -153,16 +154,21 @@ public class MatroskaFileReader {
         }
     }
 
+    public String asString(MatroskaElement element) throws IOException {
+        return asString(element, null);
+    }
+
     /**
      * @param element Element to read from
+     * @param forceCharset The charset to use, or null for default.
      * @return The contents of the element as a string
      * @throws IOException On read error
      */
-    public String asString(MatroskaElement element) throws IOException {
+    public String asString(MatroskaElement element, Charset forceCharset) throws IOException {
         if (element.is(MatroskaElementType.DataType.STRING)) {
-            return new String(asBytes(element), StandardCharsets.US_ASCII);
+            return new String(asBytes(element), forceCharset != null ? forceCharset : StandardCharsets.US_ASCII);
         } else if (element.is(MatroskaElementType.DataType.UTF8_STRING)) {
-            return new String(asBytes(element), StandardCharsets.UTF_8);
+            return new String(asBytes(element), forceCharset != null ? forceCharset : StandardCharsets.UTF_8);
         } else {
             throw new IllegalArgumentException("Not a string element.");
         }


### PR DESCRIPTION
Fixes an issue where some characters are read incorrectly, such as `塞壬唱片-MSR` which is read as `������������-MSR`