### PR TITLE
Make PersistentHttpStream$getConnectionRequest overridable

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/PersistentHttpStream.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/PersistentHttpStream.java
@@ -90,7 +90,7 @@ public class PersistentHttpStream extends SeekableInputStream implements AutoClo
         return true;
     }
 
-    private HttpGet getConnectRequest() {
+    protected HttpGet getConnectRequest() {
         HttpGet request = new HttpGet(getConnectUrl());
 
         if (position > 0 && useHeadersForRange()) {


### PR DESCRIPTION
Change visibility of the method to protected accessibility to make it overridable.
Some website requested specific headers to prevent scraping, example "Referer".