### PR TITLE
Add Request Headers (User-Agent, Referer, Origin) to Prevent 403 Errors on Some Web Servers

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/PersistentHttpStream.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/PersistentHttpStream.java
@@ -91,12 +91,25 @@ public class PersistentHttpStream extends SeekableInputStream implements AutoClo
     }
 
     protected HttpGet getConnectRequest() {
+        URI connectUrl = getConnectUrl();
         HttpGet request = new HttpGet(getConnectUrl());
 
         if (position > 0 && useHeadersForRange()) {
             request.setHeader(HttpHeaders.RANGE, "bytes=" + position + "-");
         }
-
+        
+        String targetUrl = connectUrl.toString();
+        String referer = targetUrl;
+        String origin = connectUrl.getScheme() + "://" + connectUrl.getHost();
+        
+        if (connectUrl.getPort() != -1) {
+            origin += ":" + connectUrl.getPort();
+        }
+        
+        request.setHeader(HttpHeaders.USER_AGENT, "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36 Edg/133.0.0.0");
+        request.setHeader(HttpHeaders.REFERER, referer);
+        request.setHeader(HttpHeaders.ORIGIN, origin);
+        
         return request;
     }
 


### PR DESCRIPTION
I know that a similar PR was submitted before (https://github.com/lavalink-devs/lavaplayer/pull/163) and was closed, but can this be reconsidered? 

Some web servers enforce strict header policies to protect their content. In our case, using the default Apache HttpClient headers resulted in errors, as evidenced by the following log entry:

`xxx.xxx.xx.xx - - [04/Mar/2025:03:40:44 +0700] "GET /source.mp3 HTTP/1.1" 403 3444 "-" "Apache-HttpClient/4.5.14 (Java/17.0.14)"`

This indicates that the default headers are insufficient, leading to HTTP 403 errors when accessing audio content.

Changes:
- Update the getConnectRequest() method to include custom HTTP headers:
  - **User-Agent:** Mimics a modern browser (Chrome/Edge) to prevent server-side rejections.
  - **Referer:** Set to the full target URL.
  - **Origin:** Constructed using the URI’s scheme, host, and port (if applicable) to accurately represent the request source.