### PR TITLE
Persist timecode when seeking a SoundCloudM3uAudioTrack

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/mp3/Mp3TrackProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/mp3/Mp3TrackProvider.java
@@ -157,6 +157,16 @@ public class Mp3TrackProvider implements AudioTrackInfoProvider {
     }
 
     /**
+     * Records a seek to the specified timecode without actually seeking.
+     *
+     * @param timecode The requested timecode in milliseconds
+     * @param actualTimecode The actual timecode in milliseconds
+     */
+    public void recordSeek(long timecode, long actualTimecode) {
+        downstream.seekPerformed(timecode, actualTimecode);
+    }
+
+    /**
      * @return True if the track is seekable (false for streams for example).
      */
     public boolean isSeekable() {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudMp3SegmentDecoder.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudMp3SegmentDecoder.java
@@ -33,6 +33,9 @@ public class SoundCloudMp3SegmentDecoder implements SoundCloudSegmentDecoder {
         try (SeekableInputStream stream = nextStreamProvider.get()) {
             Mp3TrackProvider trackProvider = new Mp3TrackProvider(context, stream);
 
+            // Persist the position to seek to
+            trackProvider.recordSeek(desiredPosition, startPosition);
+
             try {
                 trackProvider.parseHeaders();
                 trackProvider.provideFrames();

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudMp3SegmentDecoder.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudMp3SegmentDecoder.java
@@ -33,11 +33,12 @@ public class SoundCloudMp3SegmentDecoder implements SoundCloudSegmentDecoder {
         try (SeekableInputStream stream = nextStreamProvider.get()) {
             Mp3TrackProvider trackProvider = new Mp3TrackProvider(context, stream);
 
-            // Persist the position to seek to
-            trackProvider.recordSeek(desiredPosition, startPosition);
-
             try {
                 trackProvider.parseHeaders();
+
+                // Persist the position to seek to
+                trackProvider.recordSeek(desiredPosition, startPosition);
+
                 trackProvider.provideFrames();
             } finally {
                 trackProvider.close();


### PR DESCRIPTION
This is needed because the MP3 state gets recreated after an interrupt, which is also caused by seeking.

The change only affects the `SoundCloudMp3SegmentDecoder` and doesn't touch any previous internals, only introduces a helper method in the `Mp3TrackProvider` class.
