### PR TITLE
Check format mime type exactly rather than with `contains`

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/DefaultSoundCloudFormatHandler.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/DefaultSoundCloudFormatHandler.java
@@ -75,7 +75,7 @@ public class DefaultSoundCloudFormatHandler implements SoundCloudFormatHandler {
         }
 
         public boolean matches(SoundCloudTrackFormat format) {
-            return protocol.equals(format.getProtocol()) && format.getMimeType().contains(mimeType);
+            return protocol.equals(format.getProtocol()) && format.getMimeType().equals(mimeType);
         }
     }
 }


### PR DESCRIPTION
Should resolve some cases of stream URLs causing 404